### PR TITLE
Move the type prompts to the SDK + add split

### DIFF
--- a/examples/counter.ts
+++ b/examples/counter.ts
@@ -1,6 +1,14 @@
-import { generateWithType } from "../lib/index";
+import { generateWithType, splitString } from "../lib/index";
 import * as t from "io-ts";
 
 (async () => {
-    console.log(await generateWithType("Count from 1 to 5", t.type({ result: t.array(t.number) })));
+    // console.log(await generateWithType("Count from 1 to 5", t.type({ result: t.array(t.number) })));
+    console.log(
+        JSON.stringify(
+            splitString(
+                "What is tiktoken? and What is Tokenization?\n\nTiktoken is an open-source tool developed by OpenAI that is utilized for tokenizing text.\n\nTokenization is when you split a text string to a list of tokens. Tokens can be letters, words or grouping of words (depending on the text language).\n\nFor example, “I’m playing with AI models” can be transformed to this list [“I”,”’m”,” playing”,” with”,” AI”,” models”].\n\nThen these tokens can be encoded in integers.\n\nIn fact, this example demonstrates the functionality of the “tiktoken” library.\n\nBefore using any NLP models, you need to tokenize your dataset to be processed by the model.\n\nFurthermore, OpenAI uses a technique called byte pair encoding (BPE) for tokenization. BPE is a data compression algorithm that replaces the most frequent pairs of bytes in a text with a single byte. This reduces the size of the text and makes it easier to process.\nWhy use tiktoken?\n\nYou can use tiktoken to count tokens, because:\n\n    You need to know whether the text your are using is very long to be processed by the model\n    You need to have an idea about OpenAI API call costs (The price is applied by token).\n\n    For example, if you are using GPT-3.5-turbo model you will be charged: $0.002 / 1K tokens\n\n    You can play with it here in OpenAI platform: https://platform.openai.com/tokenizer\n\nHow to count the number of tokens using tiktoken?\nInstall and Import\n\nFirst you need to install it:\n\npip install tiktoken\n\nThen you import the library and start using it:\n\nimport tiktoken\n\nEncoding\n\nDifferent encodings are used in openai: cl100k_base, p50k_base, gpt2.\n\nThese encodings depend on the model you are using:\n\nFor gpt-4, gpt-3.5-turbo, text-embedding-ada-002, you need to use cl100k_base.\n\nAll this information is already included in OpenAI API, you don’t need to remember it. Therefore, you can call the encoding using 2 methods:\n\n",
+                100,
+            ),
+        ),
+    );
 })();

--- a/lib/generate.ts
+++ b/lib/generate.ts
@@ -1,0 +1,57 @@
+import fetch from "node-fetch";
+import * as t from "io-ts";
+
+const { POLYFACT_ENDPOINT = "https://api2.polyfact.com" } = process.env;
+const { POLYFACT_TOKEN = "" } = process.env;
+
+class GenerationError extends Error {
+    errorType?: string;
+
+    constructor(errorType?: string) {
+        switch (errorType) {
+            case "llm_init_failed":
+                super("The server failed to initialize its LLM.");
+                break;
+            case "generation_failed":
+                super("The generation failed.");
+                break;
+            default:
+                super("An unknown error occured");
+                break;
+        }
+        this.errorType = errorType || "unknown_error";
+    }
+}
+
+const ResultType = t.type({
+    result: t.string,
+    token_usage: t.type({
+        input: t.number,
+        output: t.number,
+    }),
+});
+
+async function generateWithTokenUsage(task: string): Promise<t.TypeOf<typeof ResultType>> {
+    const res = await fetch(`${POLYFACT_ENDPOINT}/generate`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-Access-Token": POLYFACT_TOKEN,
+        },
+        body: JSON.stringify({ task }),
+    }).then((res) => res.json());
+
+    if (!ResultType.is(res)) {
+        throw new GenerationError();
+    }
+
+    return res;
+}
+
+async function generate(task: string): Promise<string> {
+    const res = await generateWithTokenUsage(task);
+
+    return res.result;
+}
+
+export { generate, generateWithTokenUsage };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,110 +1,14 @@
-import fetch from "node-fetch";
-import * as t from "io-ts";
+import { generate, generateWithTokenUsage } from "./generate";
+import {
+    generateWithType,
+    generateWithTypeWithTokenUsage,
+} from "./probabilistic_helpers/generateWithType";
+import { splitString } from "./split";
 
-const API_URL = "https://api2.polyfact.com";
-const { POLYFACT_TOKEN = "" } = process.env;
-
-function internalTsio2JSON(type: any): any {
-    if (type._tag === "InterfaceType") {
-        return Object.entries(type.props)
-            .map(([key, value]) => [key, internalTsio2JSON(value)])
-            .reduce((prev, curr) => Object.assign(prev, { [curr[0]]: curr[1] }), {});
-    }
-    if (type._tag === "ArrayType") {
-        return [internalTsio2JSON(type.type)];
-    }
-    if (type._tag === "NumberType") {
-        return "number";
-    }
-    if (type._tag === "StringType") {
-        return "string";
-    }
-    if (type._tag === "BooleanType") {
-        return "boolean";
-    }
-
-    throw new Error(
-        `Unsupported type "${type}".\nPlease use one of:\n\t- InterfaceType (t.type)\n\t- ArrayType (t.array)\n\t- NumberType (t.number)\n\t- StringType (t.string)\n\t- BooleanType (t.boolean)`,
-    );
-}
-
-function tsio2JSON(type: t.TypeC<any>): any {
-    const res = JSON.parse(JSON.stringify(type));
-
-    return internalTsio2JSON(res);
-}
-
-const ErrorType = t.type({
-    error: t.string,
-});
-
-class GenerationError extends Error {
-    errorType?: string;
-
-    constructor(errorType?: string) {
-        switch (errorType) {
-            case "parse_type_failed":
-                super("The server failed to parse the provided type.");
-                break;
-            case "llm_init_failed":
-                super("The server failed to initialize its LLM.");
-                break;
-            case "generation_failed":
-                super(
-                    "The generation failed. It's usually because the task is not specific enough or doesn't match with the provided type.",
-                );
-                break;
-            default:
-                super("An unknown error occured");
-                break;
-        }
-        this.errorType = errorType || "unknown_error";
-    }
-}
-
-const ResultType = t.type({
-    result: t.any,
-    token_usage: t.type({
-        input: t.number,
-        output: t.number,
-    }),
-});
-
-async function generateWithTypeWithTokenUsage<T extends t.Props>(
-    task: string,
-    type: t.TypeC<T>,
-): Promise<{ result: t.TypeOf<t.TypeC<T>>; tokenUsage: { input: number; output: number } }> {
-    const res = await fetch(`${API_URL}/generate`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "X-Access-Token": POLYFACT_TOKEN,
-        },
-        body: JSON.stringify({ task, return_type: tsio2JSON(type) }),
-    }).then((res) => res.json());
-
-    if (!ResultType.is(res)) {
-        console.log(res);
-        throw new GenerationError();
-    }
-
-    if (!type.is(res.result)) {
-        if (ErrorType.is(res.result)) {
-            throw new GenerationError(res.result.error);
-        }
-        throw new GenerationError();
-    }
-
-    return { result: res.result, tokenUsage: res.token_usage };
-}
-
-async function generateWithType<T extends t.Props>(
-    task: string,
-    type: t.TypeC<T>,
-): Promise<t.TypeOf<t.TypeC<T>>> {
-    const res = await generateWithTypeWithTokenUsage(task, type);
-
-    return res.result;
-}
-
-export { generateWithType, generateWithTypeWithTokenUsage };
+export {
+    generate,
+    generateWithTokenUsage,
+    generateWithType,
+    generateWithTypeWithTokenUsage,
+    splitString,
+};

--- a/lib/probabilistic_helpers/generateWithType.ts
+++ b/lib/probabilistic_helpers/generateWithType.ts
@@ -1,0 +1,86 @@
+import * as t from "io-ts";
+import fetch from "node-fetch";
+import { generate, generateWithTokenUsage } from "../index";
+
+function internalTsio2JSON(type: any, indent: number): string {
+    if (type._tag === "InterfaceType") {
+        const leftpad0 = Array(2 * indent)
+            .fill(" ")
+            .join("");
+        const leftpad1 = Array(2 * (indent + 1))
+            .fill(" ")
+            .join("");
+        return `{${Object.entries(type.props)
+            .map(([key, value]) => [key, internalTsio2JSON(value, indent + 1)])
+            .reduce(
+                (prev, curr) => `${prev}\n${leftpad1}"${curr[0]}": ${curr[1]},`,
+                "",
+            )}\n${leftpad0}}`;
+    }
+    if (type._tag === "ArrayType") {
+        return `[${internalTsio2JSON(type.type, indent)}]`;
+    }
+    if (type._tag === "NumberType") {
+        return "number";
+    }
+    if (type._tag === "StringType") {
+        return "string";
+    }
+    if (type._tag === "BooleanType") {
+        return "boolean";
+    }
+
+    throw new Error(
+        `Unsupported type "${type}".\nPlease use one of:\n\t- InterfaceType (t.type)\n\t- ArrayType (t.array)\n\t- NumberType (t.number)\n\t- StringType (t.string)\n\t- BooleanType (t.boolean)`,
+    );
+}
+
+function tsio2String(type: t.TypeC<any>): string {
+    const res = JSON.parse(JSON.stringify(type));
+
+    return internalTsio2JSON(res, 0);
+}
+
+function generateTypedPrompt(typeFormat: string, task: string) {
+    return `Your goal is to write a JSON object that will accomplish a specific task.\nThe string inside the JSON must be plain text, and not contain any markdown or HTML unless explicitely mentionned in the task.\nThe JSON object should follow this type:\n\`\`\`\n${typeFormat}\n\`\`\` The task you must accomplish:\n${task}\n\nPlease only provide the JSON in a single json markdown code block with the keys described above. Do not include any other text.\nPlease make sure the JSON is a single line and does not contain any newlines outside of the strings.`;
+}
+
+export async function generateWithTypeWithTokenUsage<T extends t.Props>(
+    task: string,
+    type: t.TypeC<T>,
+): Promise<{ result: t.TypeOf<t.TypeC<T>>; tokenUsage: { input: number; output: number } }> {
+    const typeFormat = tsio2String(type);
+    const tokenUsage = { input: 0, output: 0 };
+    for (let tryCount = 0; tryCount < 5; tryCount++) {
+        const { result: resultJson, token_usage: tu } = await generateWithTokenUsage(
+            generateTypedPrompt(typeFormat, task),
+        );
+
+        tokenUsage.output += tu.output;
+        tokenUsage.input += tu.input;
+
+        let result;
+        try {
+            result = JSON.parse(resultJson);
+        } catch (e) {
+            continue;
+        }
+
+        if (!type.is(result)) {
+            continue;
+        }
+
+        return { result, tokenUsage };
+    }
+
+    throw new Error("Generation failed to match the given type after 5 retry");
+}
+
+export async function generateWithType<T extends t.Props>(
+    task: string,
+    type: t.TypeC<T>,
+): Promise<t.TypeOf<t.TypeC<T>>> {
+    const res = await generateWithTypeWithTokenUsage(task, type);
+
+    return res.result;
+}

--- a/lib/split.ts
+++ b/lib/split.ts
@@ -1,0 +1,64 @@
+import { getEncoding, TiktokenEncoding } from "js-tiktoken";
+
+function stirling(n: number) {
+    return (n / Math.E) ** n * Math.sqrt(2.0 * Math.PI * n);
+}
+
+function binomialScore(curr: number, max: number) {
+    const n = 30.0;
+    const k = (n - 2.0) * (curr / max) + 1;
+    return Math.sqrt((stirling(n) / (stirling(k) * stirling(n - k))) * 0.5 ** k * 0.5 ** (n - k));
+}
+
+function newLineScore(s: string, i: number) {
+    if (s.length === i + 1 || s[i] !== "\n") {
+        return 1.0;
+    }
+
+    if (s[i + 1] === "\n") {
+        return 50.0;
+    }
+    return 5.0;
+}
+
+function binarySplit(s: string) {
+    let maxScore = 0.0;
+    let maxScoreI = 0;
+    let lastNewLine = -1;
+    for (let i = 0; i < s.length; i++) {
+        let score = binomialScore(i, s.length) * newLineScore(s, i);
+
+        if (s[i] === "\n") {
+            if (s[lastNewLine + 1] !== "\t") {
+                score *= 50.0;
+            }
+            lastNewLine = i;
+        }
+
+        if (s[i] === " ") {
+            score *= 2.0;
+        }
+
+        if (score > maxScore) {
+            maxScore = score;
+            maxScoreI = i;
+        }
+    }
+
+    return [s.slice(0, maxScoreI), s.slice(maxScoreI)];
+}
+
+function tokenCount(s: string, model: TiktokenEncoding = "cl100k_base"): number {
+    const enc = getEncoding(model);
+    return enc.encode(s).length;
+}
+
+export function splitString(s: string, maxToken: number): string[] {
+    if (tokenCount(s) < maxToken) {
+        return [s];
+    }
+
+    const [left, right] = binarySplit(s);
+
+    return [...splitString(left, maxToken), ...splitString(right, maxToken)];
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "fp-ts": "^2.16.0",
         "io-ts": "^2.2.20",
+        "js-tiktoken": "^1.0.7",
         "node-fetch": "^2.6.1",
         "ts-node": "^10.9.1"
     },
@@ -18,6 +19,9 @@
         "@types/node-fetch": "^2.6.4",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
+        "cli-progress": "^3.12.0",
+        "commander": "^11.0.0",
+        "esbuild": "0.15.10",
         "eslint": "^7.21.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-base": "^14.2.1",
@@ -28,10 +32,7 @@
         "husky": "8.0.1",
         "koumu": "0.1.0",
         "prettier": "^2.2.1",
-        "typescript": "^4.6.2",
-        "esbuild": "0.15.10",
-        "cli-progress": "^3.12.0",
-        "commander": "^11.0.0"
+        "typescript": "^4.6.2"
     },
     "scripts": {
         "start": "ts-node cmd/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1533,6 +1538,13 @@ jju@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
+js-tiktoken@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/js-tiktoken/-/js-tiktoken-1.0.7.tgz#56933fcd2093e8304060dfde3071bda91812e6f5"
+  integrity sha512-biba8u/clw7iesNEWLOLwrNGoBP2lA+hTaBLs/D45pJdUPFXyxD6nhcDVtADChghv4GgyAiMKYMiRx7x6h7Biw==
+  dependencies:
+    base64-js "^1.5.1"
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Following [this PR](https://github.com/polyfact/polyfact-api-go/pull/5) on the API,

This PR aims to transfer the probability-based functions to the SDK with the intention of retaining only deterministic functions within the API.

Additionally, a "splitString" helper is introduced. This is a simple function that splits a string based on a maximum token limit while maintaining the integrity of the text or code structure. This is achieved by preferentially splitting at standard breakpoints such as paragraph ends, function ends, sentence ends, and so on.