### PR TITLE
Fix typo

### DIFF
--- a/lib/generate.ts
+++ b/lib/generate.ts
@@ -25,7 +25,7 @@ class GenerationError extends Error {
 
 const ResultType = t.type({
     result: t.string,
-    token_usage: t.type({
+    tokenUsage: t.type({
         input: t.number,
         output: t.number,
     }),

--- a/lib/probabilistic_helpers/generateWithType.ts
+++ b/lib/probabilistic_helpers/generateWithType.ts
@@ -84,7 +84,7 @@ export async function generateWithTypeWithTokenUsage<T extends t.Props>(
     const typeFormat = tsio2String(type);
     const tokenUsage = { input: 0, output: 0 };
     for (let tryCount = 0; tryCount < 5; tryCount++) {
-        const { result: resultJson, token_usage: tu } = await generateWithTokenUsage(
+        const { result: resultJson, tokenUsage: tu } = await generateWithTokenUsage(
             generateTypedPrompt(typeFormat, task),
         );
 


### PR DESCRIPTION
change token_usage to tokenUsage to remain consistent with other returns containing the tokenUsage property