### PR TITLE
Add description support in types

### DIFF
--- a/lib/generate.ts
+++ b/lib/generate.ts
@@ -31,7 +31,9 @@ const ResultType = t.type({
     }),
 });
 
-async function generateWithTokenUsage(task: string): Promise<t.TypeOf<typeof ResultType>> {
+async function generateWithTokenUsage(
+    task: string,
+): Promise<{ result: string; tokenUsage: { input: number; output: number } }> {
     const res = await fetch(`${POLYFACT_ENDPOINT}/generate`, {
         method: "POST",
         headers: {
@@ -45,7 +47,7 @@ async function generateWithTokenUsage(task: string): Promise<t.TypeOf<typeof Res
         throw new GenerationError();
     }
 
-    return res;
+    return { result: res.result, tokenUsage: res.token_usage };
 }
 
 async function generate(task: string): Promise<string> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ import {
     generateWithType,
     generateWithTypeWithTokenUsage,
 } from "./probabilistic_helpers/generateWithType";
+import { t } from "./probabilistic_helpers/types";
 import { splitString } from "./split";
 
 export {
@@ -11,4 +12,5 @@ export {
     generateWithType,
     generateWithTypeWithTokenUsage,
     splitString,
+    t,
 };

--- a/lib/probabilistic_helpers/types.ts
+++ b/lib/probabilistic_helpers/types.ts
@@ -1,0 +1,61 @@
+import * as tNoDesc from "io-ts";
+
+function description<T extends {}>(this: T, description: string): T {
+    return { ...this, _desc: description };
+}
+
+type ReplaceReturnType<T extends (...a: any) => any, TNewReturn> = (
+    ...a: Parameters<T>
+) => TNewReturn;
+
+type ConstantWithDescription<T extends {}> = T & {
+    description: typeof description;
+};
+
+type FunctionWithDescription<T extends (...args: any[]) => any> = ReplaceReturnType<
+    T,
+    ReturnType<T> & { description: typeof description }
+>;
+
+type newT<T extends typeof tNoDesc> = {
+    string: ConstantWithDescription<T["string"]>;
+    number: ConstantWithDescription<T["number"]>;
+    boolean: ConstantWithDescription<T["boolean"]>;
+    keyof: FunctionWithDescription<T["keyof"]>;
+    literal: FunctionWithDescription<T["literal"]>;
+    union: FunctionWithDescription<T["union"]>;
+    intersection: FunctionWithDescription<T["intersection"]>;
+    type: FunctionWithDescription<T["type"]>;
+    partial: FunctionWithDescription<T["partial"]>;
+    array: FunctionWithDescription<T["array"]>;
+};
+
+function addDescriptionToFunction(fn: any): any {
+    return (...args: any[]) => {
+        const res: any = fn(...args);
+
+        res.description = description;
+        return res;
+    };
+}
+
+function extendsT(iots: typeof tNoDesc): newT<typeof tNoDesc> {
+    const sorry = iots as any;
+
+    sorry.string.description = description;
+    sorry.number.description = description;
+    sorry.boolean.description = description;
+    sorry.keyof = addDescriptionToFunction(sorry.keyof);
+    sorry.literal = addDescriptionToFunction(sorry.literal);
+    sorry.union = addDescriptionToFunction(sorry.union);
+    sorry.intersection = addDescriptionToFunction(sorry.intersection);
+    sorry.type = addDescriptionToFunction(sorry.type);
+    sorry.partial = addDescriptionToFunction(sorry.partial);
+    sorry.array = addDescriptionToFunction(sorry.array);
+
+    return sorry as newT<typeof tNoDesc>;
+}
+
+const t = extendsT(tNoDesc);
+
+export { t };


### PR DESCRIPTION
This PR resolves #5 by creating io-ts compatible types that also support description and exporting them under the name `t`.

The descriptions can be used as shown below:
```
import { generateWithType, t } from "polyfact";

(async () => {
    console.log(
        await generateWithType(
            "Describe this function: ```function add(a, b, c) { return a + b + c }```",
            t.type({
                result: t.intersection([
                    t.type({
                        function_name: t.string,
                        arg1_name: t.string,
                        arg2_name: t.string,
                        an_unhelpful_field_name: t.string.description(
                            "A description of the given function",
                        ),
                        type: t.union([t.literal("function"), t.literal("method")]),
                    }),
                    t.partial({
                        arg3_name: t.string,
                    }),
                ]),
            }),
        ),
    );
})();
```

_(It shouldn't be in the same PR but I'm too lazy to split them: it also provide an alternative to #8 that wouldn't need to change the API)_