### PR TITLE
:sparkles: Add support for clientOptions

### DIFF
--- a/examples/createMemory.ts
+++ b/examples/createMemory.ts
@@ -1,11 +1,13 @@
 import { Memory, generate } from "../lib/index";
 
 (async () => {
-    const memory = new Memory();
+    // const memory = new Memory();
 
-    memory.add("The secret word is: banana42");
+    // memory.add("The secret word is: banana42");
 
-    const result = await generate("What is the secret word?", { memory });
+    const result = await generate("What is the secret word?", {
+        memoryId: "18ebfaa2-79c2-4b22-828a-b1c2e95cb804",
+    });
 
     console.log(result);
 })();

--- a/lib/clientOpts.ts
+++ b/lib/clientOpts.ts
@@ -1,0 +1,18 @@
+export type ClientOptions = {
+    endpoint: string;
+    token: string;
+};
+
+export function defaultOptions(opts: Partial<ClientOptions>): ClientOptions {
+    if (!(opts.token || process?.env?.POLYFACT_TOKEN)) {
+        throw new Error(
+            "Please put your polyfact token in the POLYFACT_TOKEN environment variable. You can get one at https://app.polyfact.com",
+        );
+    }
+
+    return {
+        endpoint: "https://api2.polyfact.com",
+        token: process?.env?.POLYFACT_TOKEN || "",
+        ...opts,
+    };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,14 @@
 import * as t from "polyfact-io-ts";
-import { generate, generateWithTokenUsage, GenerationOptions } from "./generate";
-import {
+import generateClient, { generate, generateWithTokenUsage, GenerationOptions } from "./generate";
+import generateWithTypeClient, {
     generateWithType,
     generateWithTypeWithTokenUsage,
 } from "./probabilistic_helpers/generateWithType";
-import { transcribe } from "./transcribe";
+import transcribeClient, { transcribe } from "./transcribe";
+import chatClient, { Chat } from "./chats";
+import memoryClient, { Memory, createMemory, updateMemory, getAllMemories } from "./memory";
 import { splitString, tokenCount } from "./split";
-import { Memory, createMemory, updateMemory, getAllMemories } from "./memory";
-import { Chat } from "./chats";
+import { ClientOptions } from "./clientOpts";
 
 export {
     generate,
@@ -25,3 +26,13 @@ export {
     Chat,
     Memory,
 };
+
+export default function client(clientOptions: Partial<ClientOptions>) {
+    return {
+        ...generateClient(clientOptions),
+        ...generateWithTypeClient(clientOptions),
+        ...transcribeClient(clientOptions),
+        ...memoryClient(clientOptions),
+        ...chatClient(clientOptions),
+    };
+}

--- a/lib/transcribe.ts
+++ b/lib/transcribe.ts
@@ -2,20 +2,17 @@ import axios from "axios";
 import FormData from "form-data";
 import { Readable } from "stream";
 import * as t from "polyfact-io-ts";
-
-const { POLYFACT_ENDPOINT = "https://api2.polyfact.com" } = process.env;
-const { POLYFACT_TOKEN = "" } = process.env;
+import { ClientOptions, defaultOptions } from "./clientOpts";
 
 const ResultType = t.type({
     text: t.string,
 });
 
-export async function transcribe(file: Buffer | Readable): Promise<string> {
-    if (!POLYFACT_TOKEN) {
-        throw new Error(
-            "Please put your polyfact token in the POLYFACT_TOKEN environment variable. You can get one at https://app.polyfact.com",
-        );
-    }
+export async function transcribe(
+    file: Buffer | Readable,
+    clientOptions: Partial<ClientOptions> = {},
+): Promise<string> {
+    const { token, endpoint } = defaultOptions(clientOptions);
 
     const formData = new FormData();
     formData.append("file", file, {
@@ -23,9 +20,9 @@ export async function transcribe(file: Buffer | Readable): Promise<string> {
         filename: "file.mp3",
     });
 
-    const res = await axios.post(`${POLYFACT_ENDPOINT}/transcribe`, formData, {
+    const res = await axios.post(`${endpoint}/transcribe`, formData, {
         headers: {
-            "X-Access-Token": POLYFACT_TOKEN,
+            "X-Access-Token": token,
         },
     });
 
@@ -36,4 +33,9 @@ export async function transcribe(file: Buffer | Readable): Promise<string> {
     }
 
     throw new Error(`Unexpected response from polyfact: ${JSON.stringify(data, null, 2)}`);
+}
+export default function client(clientOptions: Partial<ClientOptions> = {}) {
+    return {
+        transcribe: (file: Buffer | Readable) => transcribe(file, clientOptions),
+    };
 }


### PR DESCRIPTION
Allow the users to set their tokens themselves instead of always taking it from the env variables