### PR TITLE
:sparkles: Add front-end auth & projects

### DIFF
--- a/examples/repl.ts
+++ b/examples/repl.ts
@@ -1,8 +1,11 @@
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import { Chat } from "../lib/index";
+import polyfact from "../lib/index";
 
 async function main() {
+    const { Chat } = await polyfact
+        .signInWithToken(process.env.POLYFACT_TOKEN || "")
+        .project(process.env.PROJECT || "");
     const chat = new Chat({ autoMemory: true });
 
     const rl = readline.createInterface({ input, output });

--- a/examples/repl.ts
+++ b/examples/repl.ts
@@ -11,7 +11,6 @@ async function main() {
     while (true) {
         const userInput = await rl.question("> ");
 
-        //console.log(await chat.sendMessage(userInput));
         const stream = chat.sendMessageStream(userInput);
         stream.pipe(output);
         await new Promise((res) => stream.on("end", res));

--- a/examples/repl.ts
+++ b/examples/repl.ts
@@ -1,18 +1,17 @@
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import polyfact from "../lib/index";
+import Polyfact from "../lib/index";
 
 async function main() {
-    const { Chat } = await polyfact
-        .signInWithToken(process.env.POLYFACT_TOKEN || "")
-        .project(process.env.PROJECT || "");
-    const chat = new Chat({ autoMemory: true });
+    const { Chat } = Polyfact.exec();
+    const chat = new Chat({ autoMemory: true, provider: "openai" });
 
     const rl = readline.createInterface({ input, output });
 
     while (true) {
         const userInput = await rl.question("> ");
 
+        //console.log(await chat.sendMessage(userInput));
         const stream = chat.sendMessageStream(userInput);
         stream.pipe(output);
         await new Promise((res) => stream.on("end", res));

--- a/lib/chats/index.ts
+++ b/lib/chats/index.ts
@@ -31,6 +31,12 @@ export async function createChat(
     return response?.data?.id;
 }
 
+type ChatOptions = {
+    provider?: "openai" | "cohere";
+    systemPrompt?: string;
+    autoMemory?: boolean;
+};
+
 export class Chat {
     chatId: Promise<string>;
 
@@ -40,14 +46,7 @@ export class Chat {
 
     autoMemory?: Memory;
 
-    constructor(
-        options: {
-            provider?: "openai" | "cohere";
-            systemPrompt?: string;
-            autoMemory?: boolean;
-        } = {},
-        clientOptions: Partial<ClientOptions> = {},
-    ) {
+    constructor(options: ChatOptions = {}, clientOptions: Partial<ClientOptions> = {}) {
         this.clientOptions = defaultOptions(clientOptions);
         this.chatId = createChat(options.systemPrompt, this.clientOptions);
         this.provider = options.provider || "openai";
@@ -138,7 +137,10 @@ export class Chat {
 export default function client(clientOptions: Partial<ClientOptions> = {}) {
     return {
         createChat: (systemPrompt?: string) => createChat(systemPrompt, clientOptions),
-        Chat: (options?: { provider?: "openai" | "cohere"; systemPrompt?: string }) =>
-            new Chat(options, clientOptions),
+        Chat: class C extends Chat {
+            constructor(options: ChatOptions = {}) {
+                super(options, clientOptions);
+            }
+        },
     };
 }

--- a/lib/chats/index.ts
+++ b/lib/chats/index.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 import * as t from "polyfact-io-ts";
-import { Readable, PassThrough } from "stream";
+import { Readable, PassThrough } from "readable-stream";
 import { generateStream, generateWithTokenUsage, GenerationOptions } from "../generate";
-import { ClientOptions, defaultOptions } from "../clientOpts";
+import { InputClientOptions, ClientOptions, defaultOptions } from "../clientOpts";
 import { Memory } from "../memory";
 
 const Message = t.type({
@@ -14,9 +14,9 @@ const Message = t.type({
 });
 export async function createChat(
     systemPrompt?: string,
-    options: Partial<ClientOptions> = {},
+    options: InputClientOptions = {},
 ): Promise<string> {
-    const { token, endpoint } = defaultOptions(options);
+    const { token, endpoint } = await defaultOptions(options);
 
     const response = await axios.post(
         `${endpoint}/chats`,
@@ -32,7 +32,7 @@ export async function createChat(
 }
 
 type ChatOptions = {
-    provider?: "openai" | "cohere";
+    provider?: "openai" | "cohere" | "llama";
     systemPrompt?: string;
     autoMemory?: boolean;
 };
@@ -40,18 +40,18 @@ type ChatOptions = {
 export class Chat {
     chatId: Promise<string>;
 
-    provider: "openai" | "cohere";
+    provider: "openai" | "cohere" | "llama";
 
-    clientOptions: ClientOptions;
+    clientOptions: Promise<ClientOptions>;
 
-    autoMemory?: Memory;
+    autoMemory?: Promise<Memory>;
 
-    constructor(options: ChatOptions = {}, clientOptions: Partial<ClientOptions> = {}) {
+    constructor(options: ChatOptions = {}, clientOptions: InputClientOptions = {}) {
         this.clientOptions = defaultOptions(clientOptions);
         this.chatId = createChat(options.systemPrompt, this.clientOptions);
         this.provider = options.provider || "openai";
         if (options.autoMemory) {
-            this.autoMemory = new Memory(this.clientOptions);
+            this.autoMemory = this.clientOptions.then((co) => new Memory(co));
         }
     }
 
@@ -62,18 +62,18 @@ export class Chat {
         const chatId = await this.chatId;
 
         if (this.autoMemory && !options.memory && !options.memoryId) {
-            options.memory = this.autoMemory;
+            options.memory = await this.autoMemory;
         }
 
         const result = await generateWithTokenUsage(
             message,
-            { ...options, chatId },
+            { provider: this.provider, ...options, chatId },
             this.clientOptions,
         );
 
         if (this.autoMemory) {
-            this.autoMemory.add(`Human: ${message}`);
-            this.autoMemory.add(`AI: ${result.result}`);
+            (await this.autoMemory).add(`Human: ${message}`);
+            (await this.autoMemory).add(`AI: ${result.result}`);
         }
 
         return result;
@@ -92,10 +92,14 @@ export class Chat {
             const chatId = await this.chatId;
 
             if (this.autoMemory && !options.memory && !options.memoryId) {
-                options.memory = this.autoMemory;
+                options.memory = await this.autoMemory;
             }
 
-            const result = generateStream(message, { ...options, chatId }, this.clientOptions);
+            const result = generateStream(
+                message,
+                { provider: this.provider, ...options, chatId },
+                this.clientOptions,
+            );
 
             result.pipe(resultStream);
 
@@ -110,20 +114,20 @@ export class Chat {
             });
 
             if (this.autoMemory) {
-                this.autoMemory.add(`Human: ${message}`);
-                this.autoMemory.add(`AI: ${totalResult}`);
+                (await this.autoMemory).add(`Human: ${message}`);
+                (await this.autoMemory).add(`AI: ${totalResult}`);
             }
         })();
 
-        return resultStream;
+        return resultStream as unknown as Readable;
     }
 
     async getMessages(): Promise<t.TypeOf<typeof Message>[]> {
         const response = await axios.get(
-            `${this.clientOptions.endpoint}/chat/${await this.chatId}/history`,
+            `${(await this.clientOptions).endpoint}/chat/${await this.chatId}/history`,
             {
                 headers: {
-                    "X-Access-Token": this.clientOptions.token,
+                    "X-Access-Token": (await this.clientOptions).token,
                 },
             },
         );
@@ -134,7 +138,7 @@ export class Chat {
     }
 }
 
-export default function client(clientOptions: Partial<ClientOptions> = {}) {
+export default function client(clientOptions: InputClientOptions = {}) {
     return {
         createChat: (systemPrompt?: string) => createChat(systemPrompt, clientOptions),
         Chat: class C extends Chat {

--- a/lib/clientOpts.ts
+++ b/lib/clientOpts.ts
@@ -1,3 +1,5 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
 export type ClientOptions = {
     endpoint: string;
     token: string;

--- a/lib/clientOpts.ts
+++ b/lib/clientOpts.ts
@@ -1,20 +1,24 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { POLYFACT_ENDPOINT, POLYFACT_TOKEN } from "./utils";
 
 export type ClientOptions = {
     endpoint: string;
     token: string;
 };
 
-export function defaultOptions(opts: Partial<ClientOptions>): ClientOptions {
-    if (!(opts.token || process?.env?.POLYFACT_TOKEN)) {
+export type InputClientOptions = Partial<ClientOptions> | Promise<Partial<ClientOptions>>;
+
+export async function defaultOptions(popts: InputClientOptions): Promise<ClientOptions> {
+    const opts = await popts;
+    if (!opts.token && !POLYFACT_TOKEN) {
         throw new Error(
             "Please put your polyfact token in the POLYFACT_TOKEN environment variable. You can get one at https://app.polyfact.com",
         );
     }
 
     return {
-        endpoint: process?.env.POLYFACT_ENDPOINT || "https://api2.polyfact.com",
-        token: process?.env?.POLYFACT_TOKEN || "",
+        endpoint: POLYFACT_ENDPOINT || "https://api2.polyfact.com",
+        token: POLYFACT_TOKEN || "",
         ...opts,
     };
 }

--- a/lib/helpers/ensurePolyfactToken.ts
+++ b/lib/helpers/ensurePolyfactToken.ts
@@ -1,9 +1,0 @@
-const { POLYFACT_TOKEN = "" } = process.env;
-
-export function ensurePolyfactToken(): void {
-    if (!POLYFACT_TOKEN) {
-        throw new Error(
-            "Please put your polyfact token in the POLYFACT_TOKEN environment variable. You can get one at https://app.polyfact.com",
-        );
-    }
-}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,7 +11,7 @@ import transcribeClient, { transcribe } from "./transcribe";
 import chatClient, { Chat } from "./chats";
 import memoryClient, { Memory, createMemory, updateMemory, getAllMemories } from "./memory";
 import { splitString, tokenCount } from "./split";
-import { ClientOptions, defaultOptions, InputClientOptions } from "./clientOpts";
+import { InputClientOptions } from "./clientOpts";
 import kvClient, { get as KVGet, set as KVSet } from "./kv";
 
 const kv = {
@@ -203,7 +203,15 @@ export default Polyfact;
 
 declare const window: any;
 
-export function usePolyfact({ provider, project }: { provider: "github"; project: string }) {
+export function usePolyfact({
+    provider,
+    project,
+    endpoint,
+}: {
+    provider: "github";
+    project: string;
+    endpoint?: string;
+}): ReturnType<typeof client> {
     if (typeof window === "undefined") {
         throw new Error("usePolyfact not usable outside of the browser environment");
     }
@@ -223,7 +231,7 @@ export function usePolyfact({ provider, project }: { provider: "github"; project
     }
 
     if (token) {
-        const p = Polyfact.endpoint("http://localhost:8080")
+        const p = Polyfact.endpoint(endpoint || "https://api2.polyfact.com")
             .project(project)
             .signInWithToken(token)
             .exec();
@@ -231,7 +239,7 @@ export function usePolyfact({ provider, project }: { provider: "github"; project
 
         return p;
     }
-    const p = Polyfact.endpoint("http://localhost:8080")
+    const p = Polyfact.endpoint(endpoint || "https://api2.polyfact.com")
         .project(project)
         .signInWithOAuth({ provider })
         .exec();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -203,13 +203,11 @@ declare const window: any;
 
 const reactMutex = new Mutex();
 
-export function usePolyfact({
-    project,
-    endpoint,
-}: {
-    project: string;
-    endpoint?: string;
-}): [ReturnType<typeof client>, (input: { provider: "github" }) => Promise<void>, boolean] {
+export function usePolyfact({ project, endpoint }: { project: string; endpoint?: string }): {
+    polyfact: ReturnType<typeof client>;
+    login: (input: { provider: "github" }) => Promise<void>;
+    loading: boolean;
+} {
     if (typeof window === "undefined") {
         throw new Error("usePolyfact not usable outside of the browser environment");
     }
@@ -251,5 +249,5 @@ export function usePolyfact({
         })();
     }, []);
 
-    return [polyfact, login, loading];
+    return { polyfact, login, loading };
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -179,6 +179,7 @@ export class PolyfactClientBuilder implements PromiseLike<ReturnType<typeof clie
 
             console.log(data);
         });
+        this.buildQueue.push(() => new Promise<void>(() => {})); // Since it should redirect to another page, the promise shouldn't resolve.
         return this;
     }
 
@@ -209,10 +210,16 @@ export function usePolyfact({ provider, project }: { provider: "github"; project
 
     const react = require("react"); // eslint-disable-line
     const [polyfact, setPolyfact] = react.useState();
-    const token = new URLSearchParams(window.location.hash.replace(/^#/, "?")).get("access_token");
+    let token = new URLSearchParams(window.location.hash.replace(/^#/, "?")).get("access_token");
 
     if (polyfact) {
         return polyfact;
+    }
+
+    if (!token && window.localStorage.getItem("polyfact_token")) {
+        token = window.localStorage.getItem("polyfact_token");
+    } else if (token) {
+        window.localStorage.setItem("polyfact_token", token);
     }
 
     if (token) {

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
-import { ClientOptions, defaultOptions } from "./clientOpts";
+import { InputClientOptions, ClientOptions, defaultOptions } from "./clientOpts";
 
 export async function set(
     key: string,
     value: string,
-    clientOptions: Partial<ClientOptions> = {},
+    clientOptions: InputClientOptions = {},
 ): Promise<void> {
-    const { token, endpoint } = defaultOptions(clientOptions);
+    const { token, endpoint } = await defaultOptions(clientOptions);
 
     await axios.put(
         `${endpoint}/kv`,
@@ -23,11 +23,8 @@ export async function set(
     );
 }
 
-export async function get(
-    key: string,
-    clientOptions: Partial<ClientOptions> = {},
-): Promise<string> {
-    const { token, endpoint } = defaultOptions(clientOptions);
+export async function get(key: string, clientOptions: InputClientOptions = {}): Promise<string> {
+    const { token, endpoint } = await defaultOptions(clientOptions);
 
     const response = await axios
         .get(`${endpoint}/kv?key=${key}`, {
@@ -44,7 +41,7 @@ export async function get(
     return response.data;
 }
 
-export default function client(clientOptions: Partial<ClientOptions> = {}) {
+export default function client(clientOptions: InputClientOptions = {}) {
     return {
         get: (key: string) => get(key, clientOptions),
         set: (key: string, value: string) => set(key, value, clientOptions),

--- a/lib/probabilistic_helpers/generateWithType.ts
+++ b/lib/probabilistic_helpers/generateWithType.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import * as t from "polyfact-io-ts";
 import { generateWithTokenUsage, GenerationOptions } from "../index";
-import { ClientOptions } from "../clientOpts";
+import { ClientOptions, InputClientOptions } from "../clientOpts";
 
 function typePartial2String(entries: [string, any][], indent: number, partial: boolean): string {
     const leftpad = Array(2 * (indent + 1))
@@ -86,7 +86,7 @@ export async function generateWithTypeWithTokenUsage<T extends t.Props>(
     task: string,
     type: t.TypeC<T>,
     options: GenerationOptions = {},
-    clientOptions: Partial<ClientOptions> = {},
+    clientOptions: InputClientOptions = {},
 ): Promise<{ result: t.TypeOf<t.TypeC<T>>; tokenUsage: { input: number; output: number } }> {
     const typeFormat = tsio2String(type);
     const tokenUsage = { input: 0, output: 0 };
@@ -126,14 +126,14 @@ export async function generateWithType<T extends t.Props>(
     task: string,
     type: t.TypeC<T>,
     options: GenerationOptions = {},
-    clientOptions: Partial<ClientOptions> = {},
+    clientOptions: InputClientOptions = {},
 ): Promise<t.TypeOf<t.TypeC<T>>> {
     const res = await generateWithTypeWithTokenUsage(task, type, options, clientOptions);
 
     return res.result;
 }
 
-export default function client(clientOptions: Partial<ClientOptions> = {}) {
+export default function client(clientOptions: InputClientOptions = {}) {
     return {
         generateWithTypeWithTokenUsage: <T extends t.Props>(
             task: string,

--- a/lib/transcribe.ts
+++ b/lib/transcribe.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 import FormData from "form-data";
-import { Readable } from "stream";
+import { Readable } from "readable-stream";
 import * as t from "polyfact-io-ts";
-import { ClientOptions, defaultOptions } from "./clientOpts";
+import { InputClientOptions, defaultOptions } from "./clientOpts";
 
 const ResultType = t.type({
     text: t.string,
@@ -10,9 +10,9 @@ const ResultType = t.type({
 
 export async function transcribe(
     file: Buffer | Readable,
-    clientOptions: Partial<ClientOptions> = {},
+    clientOptions: InputClientOptions = {},
 ): Promise<string> {
-    const { token, endpoint } = defaultOptions(clientOptions);
+    const { token, endpoint } = await defaultOptions(clientOptions);
 
     const formData = new FormData();
     formData.append("file", file, {
@@ -34,7 +34,7 @@ export async function transcribe(
 
     throw new Error(`Unexpected response from polyfact: ${JSON.stringify(data, null, 2)}`);
 }
-export default function client(clientOptions: Partial<ClientOptions> = {}) {
+export default function client(clientOptions: InputClientOptions = {}) {
     return {
         transcribe: (file: Buffer | Readable) => transcribe(file, clientOptions),
     };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,10 @@
+let token: string | undefined;
+let endpoint: string | undefined;
+
+if (typeof process !== "undefined") {
+    token = process?.env?.POLYFACT_TOKEN;
+    endpoint = process?.env?.POLYFACT_ENDPOINT;
+}
+
+export const POLYFACT_TOKEN = token;
+export const POLYFACT_ENDPOINT = endpoint;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "name": "polyfact",
     "version": "0.1.25",
-    "main": "dist/index.node.js",
-    "browser": "dist/index.js",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "author": "Lancelot Owczarczak <lancelot@owczarczak.fr>",
     "license": "MIT",
@@ -47,8 +46,6 @@
         "lint": "prettier --check lib/ cmd/ ; eslint lib/ cmd/",
         "lint:fix": "prettier --write lib/ cmd/ ; eslint --fix lib/ cmd/",
         "cmd:build": "esbuild cmd/index.ts --bundle --outfile=build/polyfact.tmp --platform=node && echo -n '#!/usr/bin/env node\n' | cat - build/polyfact.tmp > build/polyfact && rm build/polyfact.tmp",
-        "node:build": "mkdir -p dist && esbuild lib/index.ts --bundle --platform=node --target=node18 > dist/index.node.js && tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
-        "browser:build": "mkdir -p dist && esbuild lib/index.ts --bundle '--define:process.env.NODE_ENV=\"production\"' > dist/index.browser.js && tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
         "build": "tsc -p tsconfig.json --declaration --outDir dist"
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "bin": "build/polyfact",
     "dependencies": {
+        "@supabase/supabase-js": "^2.31.0",
         "axios": "^1.4.0",
         "form-data": "^4.0.0",
         "fp-ts": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "polyfact",
-    "version": "0.1.35",
+    "version": "0.1.36",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "author": "Lancelot Owczarczak <lancelot@owczarczak.fr>",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "@supabase/supabase-js": "^2.31.0",
         "@types/readable-stream": "^4.0.0",
+        "async-mutex": "^0.4.0",
         "axios": "^0.27.2",
         "form-data": "^4.0.0",
         "fp-ts": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,23 @@
 {
     "name": "polyfact",
     "version": "0.1.25",
-    "main": "dist/index.js",
+    "main": "dist/index.node.js",
+    "browser": "dist/index.js",
     "types": "dist/index.d.ts",
     "author": "Lancelot Owczarczak <lancelot@owczarczak.fr>",
     "license": "MIT",
     "bin": "build/polyfact",
     "dependencies": {
         "@supabase/supabase-js": "^2.31.0",
-        "axios": "^1.4.0",
+        "@types/readable-stream": "^4.0.0",
+        "axios": "^0.27.2",
         "form-data": "^4.0.0",
         "fp-ts": "^2.16.0",
         "isomorphic-fetch": "^3.0.0",
         "isomorphic-ws": "^5.0.0",
         "js-tiktoken": "^1.0.7",
         "polyfact-io-ts": "^2.2.20",
+        "readable-stream": "^4.4.2",
         "ts-node": "^10.9.1",
         "ws": "^8.13.0"
     },
@@ -44,6 +47,8 @@
         "lint": "prettier --check lib/ cmd/ ; eslint lib/ cmd/",
         "lint:fix": "prettier --write lib/ cmd/ ; eslint --fix lib/ cmd/",
         "cmd:build": "esbuild cmd/index.ts --bundle --outfile=build/polyfact.tmp --platform=node && echo -n '#!/usr/bin/env node\n' | cat - build/polyfact.tmp > build/polyfact && rm build/polyfact.tmp",
+        "node:build": "mkdir -p dist && esbuild lib/index.ts --bundle --platform=node --target=node18 > dist/index.node.js && tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
+        "browser:build": "mkdir -p dist && esbuild lib/index.ts --bundle '--define:process.env.NODE_ENV=\"production\"' > dist/index.browser.js && tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
         "build": "tsc -p tsconfig.json --declaration --outDir dist"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
     "compilerOptions": {
-        "target": "es2021",
+        "target": "es5",
         "lib": [
-            "es2021",
+            "es5",
             "DOM",
         ],
-        "module": "commonjs",
         "strict": true,
         "esModuleInterop": true,
         "allowJs": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,6 +244,14 @@
   resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.6.0.tgz#eb7536259ee695646e75c4c7b0c9a857ea174781"
   integrity sha512-qwfpsHmFuhAS/dVd4uBIraMxRd56vwBUYQGZ6GpXnFuM2XMRFJbIyruFKKlW2daQliuYZwe0qfn/UjFCDKic5g==
 
+"@types/readable-stream@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-4.0.0.tgz#9bcb888b9c77478b02490365d3e0c34fd8b6d5ae"
+  integrity sha512-s6YqDV111kwuFsT9SwFC+FmZ5n1SEp4H9DXGg6Zqag0lPGeEvBGP9UaLJYpX4cxY7fAFnx2avy1QVvft0LLb7g==
+  dependencies:
+    "@types/node" "*"
+    safe-buffer "~5.1.1"
+
 "@types/websocket@^1.0.3":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.5.tgz#3fb80ed8e07f88e51961211cd3682a3a4a81569c"
@@ -320,6 +328,13 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 acorn-jsx@^5.3.1:
   version "5.3.2"
@@ -456,21 +471,20 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
-  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.14.9"
     form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.5.1:
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -489,6 +503,14 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bufferutil@^4.0.1:
   version "4.0.7"
@@ -1245,6 +1267,16 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 ext@^1.1.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
@@ -1312,7 +1344,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.15.0:
+follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -1488,6 +1520,11 @@ husky@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
   integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -1965,6 +2002,11 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -1977,11 +2019,6 @@ prompts@noomly/prompts#e282568af270a0bd625dc377bb5d83f37991efc3:
     kleur "^4.0.1"
     sisteransi "^1.0.5"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
 punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
@@ -1991,6 +2028,17 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+readable-stream@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
+  integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
 
 regexp.prototype.flags@^1.4.3:
   version "1.5.0"
@@ -2051,6 +2099,16 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.0.0:
   version "1.0.0"
@@ -2153,6 +2211,13 @@ string.prototype.trimstart@^1.0.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,6 +138,55 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@supabase/functions-js@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@supabase/functions-js/-/functions-js-2.1.2.tgz#340a8d3845ef2014338b13a6d33cfa90eb745b14"
+  integrity sha512-QCR6pwJs9exCl37bmpMisUd6mf+0SUBJ6mUpiAjEkSJ/+xW8TCuO14bvkWHADd5hElJK9MxNlMQXxSA4DRz9nQ==
+  dependencies:
+    cross-fetch "^3.1.5"
+
+"@supabase/gotrue-js@^2.46.1":
+  version "2.46.1"
+  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-2.46.1.tgz#c4ac5056a02498db6d9edccab4e4d6db4fe7e3e1"
+  integrity sha512-tebFX3XvPqEJKHOVgkXTN20g9iUhLx6tebIYQvTggYTrqOT2af8oTpSBdgYzbwJ291G6P6CSpR6KY0cT9ade5A==
+  dependencies:
+    cross-fetch "^3.1.5"
+
+"@supabase/postgrest-js@^1.7.0":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-1.7.2.tgz#800814b98bb8cec840b65f0c545a3474f23c343a"
+  integrity sha512-GK80JpRq8l6Qll85erICypAfQCied8tdlXfsDN14W844HqXCSOisk8AaE01DAwGJanieaoN5fuqhzA2yKxDvEQ==
+  dependencies:
+    cross-fetch "^3.1.5"
+
+"@supabase/realtime-js@^2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-2.7.3.tgz#cbcb84181add681ab99c87032bfe88101c6863b3"
+  integrity sha512-c7TzL81sx2kqyxsxcDduJcHL9KJdCOoKimGP6lQSqiZKX42ATlBZpWbyy9KFGFBjAP4nyopMf5JhPi2ZH9jyNw==
+  dependencies:
+    "@types/phoenix" "^1.5.4"
+    "@types/websocket" "^1.0.3"
+    websocket "^1.0.34"
+
+"@supabase/storage-js@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-2.5.1.tgz#16c4c088996e0395034717836e626f14df63a349"
+  integrity sha512-nkR0fQA9ScAtIKA3vNoPEqbZv1k5B5HVRYEvRWdlP6mUpFphM9TwPL2jZ/ztNGMTG5xT6SrHr+H7Ykz8qzbhjw==
+  dependencies:
+    cross-fetch "^3.1.5"
+
+"@supabase/supabase-js@^2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-2.31.0.tgz#49fe09652fa72b1173efe4ac086592e31c662cef"
+  integrity sha512-W9/4s+KnSUX67wJKBn/3yLq+ieycnMzVjK3nNTLX5Wko3ypNT/081l2iFYrf+nsLQ1CiT4mA92I3dxCy6CmxTg==
+  dependencies:
+    "@supabase/functions-js" "^2.1.0"
+    "@supabase/gotrue-js" "^2.46.1"
+    "@supabase/postgrest-js" "^1.7.0"
+    "@supabase/realtime-js" "^2.7.3"
+    "@supabase/storage-js" "^2.5.1"
+    cross-fetch "^3.1.5"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -189,6 +238,18 @@
   version "20.4.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.5.tgz#9dc0a5cb1ccce4f7a731660935ab70b9c00a5d69"
   integrity sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==
+
+"@types/phoenix@^1.5.4":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.6.0.tgz#eb7536259ee695646e75c4c7b0c9a857ea174781"
+  integrity sha512-qwfpsHmFuhAS/dVd4uBIraMxRd56vwBUYQGZ6GpXnFuM2XMRFJbIyruFKKlW2daQliuYZwe0qfn/UjFCDKic5g==
+
+"@types/websocket@^1.0.3":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.5.tgz#3fb80ed8e07f88e51961211cd3682a3a4a81569c"
+  integrity sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^4.14.1":
   version "4.33.0"
@@ -429,6 +490,13 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+bufferutil@^4.0.1:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.7.tgz#60c0d19ba2c992dd8273d3f73772ffc894c153ad"
+  integrity sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -522,6 +590,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.1.5:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -530,6 +605,21 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
+
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@^3.2.7:
   version "3.2.7"
@@ -665,6 +755,32 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es5-ext@^0.10.35, es5-ext@^0.10.50:
+  version "0.10.62"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.62.tgz#5e6adc19a6da524bf3d1e02bbc8960e5eb49a9a5"
+  integrity sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    next-tick "^1.1.0"
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
 
 esbuild-android-64@0.14.54:
   version "0.14.54"
@@ -1129,6 +1245,13 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+ext@^1.1.2:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
+  dependencies:
+    type "^2.7.2"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1528,6 +1651,11 @@ is-typed-array@^1.1.10, is-typed-array@^1.1.9:
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
@@ -1689,6 +1817,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1704,6 +1837,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
+
 node-emoji@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
@@ -1711,12 +1849,17 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gyp-build@^4.3.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
+  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
 object-inspect@^1.12.3, object-inspect@^1.9.0:
   version "1.12.3"
@@ -2128,6 +2271,16 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
+  integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
+
 typed-array-length@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
@@ -2136,6 +2289,13 @@ typed-array-length@^1.0.4:
     call-bind "^1.0.2"
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typescript@^4.6.2:
   version "4.9.5"
@@ -2159,6 +2319,13 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+utf-8-validate@^5.0.2:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
+  integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -2173,6 +2340,18 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+websocket@^1.0.34:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
 
 whatwg-fetch@^3.4.1:
   version "3.6.17"
@@ -2226,6 +2405,11 @@ ws@^8.13.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,6 +461,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async-mutex@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.4.0.tgz#ae8048cd4d04ace94347507504b3cf15e631c25f"
+  integrity sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==
+  dependencies:
+    tslib "^2.4.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2316,6 +2323,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
+  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Allow users to connect from a front end using the exported `usePolyfact` hook and specifying a projectId